### PR TITLE
add support for code lengths 1 through 8

### DIFF
--- a/qml/components/harbour.sgauth.QGoogleAuthStorage.js
+++ b/qml/components/harbour.sgauth.QGoogleAuthStorage.js
@@ -101,7 +101,7 @@ function getAccounts() {
     return accounts;
 }
 
-function insertAccount(name, key, type, counter) {
+function insertAccount(name, key, type, counter, digits) {
     var db = getDatabase();
     var sortorder = 1;
 
@@ -112,7 +112,7 @@ function insertAccount(name, key, type, counter) {
     });
 
     db.transaction(function(tx) {
-        var rs = tx.executeSql("INSERT INTO Account (Name,Key,Type,Counter,SortOrder) VALUES(?,?,?,?,?)", [name, key, type, counter, sortorder]);
+        var rs = tx.executeSql("INSERT INTO Account (Name,Key,Type,Counter,Digits,SortOrder) VALUES(?,?,?,?,?,?)", [name, key, type, counter, digits, sortorder]);
 
         return rs.insertId;
     });
@@ -120,11 +120,11 @@ function insertAccount(name, key, type, counter) {
     return -1;
 }
 
-function updateAccount(id, name, key, type, counter) {
+function updateAccount(id, name, key, type, counter, digits) {
     var db = getDatabase();
 
     db.transaction(function(tx) {
-        var rs = tx.executeSql("UPDATE Account SET Name=?,Key=?,Type=?,Counter=? WHERE ID = ?", [name, key, type, counter, id]);
+        var rs = tx.executeSql("UPDATE Account SET Name=?,Key=?,Type=?,Counter=?,Digits=? WHERE ID = ?", [name, key, type, counter, digits, id]);
 
         return rs.rowsAffected;
     });

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -12,7 +12,7 @@ CoverBackground {
         // Now refresh passcodes for all cover accounts
         for (var i = 0; i < accountsCoverModel.count; i++) {
             var currentlistAccount = accountsCoverModel.get(i)
-            accountsCoverModel.setProperty(i, "accountPasscode", QGoogleAuth.generatePin(currentlistAccount.accountKey,currentlistAccount.accountType,currentlistAccount.accountCounter))
+            accountsCoverModel.setProperty(i, "accountPasscode", QGoogleAuth.generatePin(currentlistAccount.accountKey,currentlistAccount.accountType,currentlistAccount.accountCounter,currentlistAccount.accountDigits))
 
             if (currentlistAccount.accountType == "TOTP") {
                 coverRoot.hasTOTPAccounts = true
@@ -36,6 +36,7 @@ CoverBackground {
                     "accountKey": accounts[i]["accountKey"],
                     "accountType": accounts[i]["accountType"],
                     "accountCounter": accounts[i]["accountCounter"],
+                    "accountDigits": accounts[i]["accountDigits"],
                     "accountPasscode": ""
                 })
             }

--- a/qml/dialogs/AddNewAccountDialog.qml
+++ b/qml/dialogs/AddNewAccountDialog.qml
@@ -6,6 +6,7 @@ Dialog {
     property string newAccountKey: ""
     property string newAccountType: "TOTP"
     property int newAccountCounter: 1
+    property int newAccountDigits: 6
 
     Column {
         anchors.fill: parent
@@ -63,7 +64,7 @@ Dialog {
             EnterKey.enabled: text.length >= 16
             EnterKey.onClicked: {
                 if (keyField.text.length >= 16)
-                    keyField.focus = false
+                    digitsField.focus = true
             }
         }
 
@@ -71,6 +72,18 @@ Dialog {
             color: "transparent"
             width: parent.width
             height: Theme.paddingSmall
+        }
+
+
+        TextField {
+            id: digitsField
+            width: parent.width
+            text: newAccountDigits
+            placeholderText: "Code digits"
+            label: "Code digits"
+            validator: IntValidator { bottom: 1; top: 8; }
+            inputMethodHints: Qt.ImhDigitsOnly
+            EnterKey.onClicked: digitsField.focus = false
         }
 
         ComboBox {
@@ -110,7 +123,7 @@ Dialog {
 
     }
 
-    canAccept: keyField.text.length >= 16 && nameField.text.length >= 1 && (typeComboBox.currentIndex == 0 || parseInt(counterField.text,10) >= 1) ? true : false
+    canAccept: keyField.text.length >= 16 && nameField.text.length >= 1 && (typeComboBox.currentIndex == 0 || parseInt(counterField.text,10) >= 1) && digitsField.text.length >= 1 ? true : false
 
     onDone: {
         if (result == DialogResult.Accepted) {
@@ -119,6 +132,7 @@ Dialog {
             newAccountCounter = parseInt(counterField.text,10) || 1
             if (newAccountCounter < 1)
                 newAccountCounter = 1;
+            newAccountDigits = parseInt(digitsField.text,10);
 
             newAccountType = typeComboBox.currentIndex == 0 ? "TOTP" : "HOTP"
         }

--- a/qml/dialogs/EditAccountDialog.qml
+++ b/qml/dialogs/EditAccountDialog.qml
@@ -8,14 +8,16 @@ Dialog {
     property string editAccountKey
     property string editAccountType
     property int editAccountCounter
+    property int editAccountDigits
 
     function refreshQRImage() {
         var counterValue = parseInt(counterField.text,10) || 1;
         if (counterValue < 1)
             counterValue = 1;
         var accountType = typeComboBox.currentIndex == 0 ? "TOTP" : "HOTP";
+        var digitsValue = parseInt(digitsField.text,10) || 6;
 
-        var otpauth = QGoogleAuth.createOTPAuth(accountType, nameField.text, keyField.text, counterValue)
+        var otpauth = QGoogleAuth.createOTPAuth(accountType, nameField.text, keyField.text, counterValue, digitsValue)
         if (otpauth.length && nameField.text.length > 0 && keyField.text.length >= 16 && (accountType == "TOTP" || (accountType == "HOTP" && counterValue >= 1))) {
             BarcodeWriter.encode(otpauth);
             scannableImage.source = ""
@@ -91,7 +93,7 @@ Dialog {
                 EnterKey.enabled: text.length > 0 && canAccept
                 EnterKey.onClicked: {
                     if (keyField.text.length >= 16)
-                        keyField.focus = false
+                        digitsField.focus = true
                 }
 
                 onTextChanged: {
@@ -103,6 +105,20 @@ Dialog {
                 color: "transparent"
                 width: parent.width
                 height: Theme.paddingSmall
+            }
+
+            TextField {
+                id: digitsField
+                width: parent.width
+                text: editAccountDigits
+                placeholderText: "Code digits"
+                label: "Code digits"
+                validator: IntValidator { bottom: 1; top: 8; }
+                inputMethodHints: Qt.ImhDigitsOnly
+                EnterKey.onClicked: digitsField.focus = false
+                onTextChanged: {
+                    refreshQRImage();
+                }
             }
 
             ComboBox {
@@ -194,7 +210,7 @@ Dialog {
         }
     }
 
-    canAccept: keyField.text.length >= 16 && nameField.text.length >= 1 ? true : false
+    canAccept: keyField.text.length >= 16 && nameField.text.length >= 1 && digitsField.text.length >= 1 ? true : false
 
     onDone: {
         if (result == DialogResult.Accepted) {
@@ -203,7 +219,7 @@ Dialog {
             editAccountCounter = parseInt(counterField.text,10) || 1
             if (editAccountCounter < 1)
                 editAccountCounter = 1;
-
+            editAccountDigits = parseInt(digitsField.text,10);
             editAccountType = typeComboBox.currentIndex == 0 ? "TOTP" : "HOTP"
         }
     }

--- a/src/qgoogleauth.h
+++ b/src/qgoogleauth.h
@@ -12,10 +12,10 @@ public:
     QGoogleAuth(QObject *parent = 0);
     virtual ~QGoogleAuth();
 
-    Q_INVOKABLE QString generatePin(const QByteArray key, const QString type = "TOTP", quint64 counter = 1);
+    Q_INVOKABLE QString generatePin(const QByteArray key, const QString type = "TOTP", quint64 counter = 1, unsigned digits = 6);
     Q_INVOKABLE uint timeLeft();
     Q_INVOKABLE QVariantMap parseOTPAuth(const QString otpauth);
-    Q_INVOKABLE QString createOTPAuth(const QString type, const QString label, const QString secret, quint64 counter);
+    Q_INVOKABLE QString createOTPAuth(const QString type, const QString label, const QString secret, quint64 counter, unsigned digits);
 };
 
 #endif // QGOOGLEAUTH_H


### PR DESCRIPTION
This adds support for OTP codes with a different number of digits than 6 (1 through 8 currently).

Generating codes with length 8, editing existing digit lengths and scanning a barcode URI with the digits query parameter set to 8 all seem to work on device (Jolla), but I suck at both C++ and JS, so bugs probable.